### PR TITLE
Adding mamba usage instructions

### DIFF
--- a/docs/usage-complete.md
+++ b/docs/usage-complete.md
@@ -451,6 +451,8 @@ start at the beginning.
 Nextflow Profile Parameters
   --condadir                    [string]  Directory to Nextflow should use for Conda
                                             environments
+  --use_mamba                   [boolean] Uses mamba instead of conda for building 
+                                            environments [default: false]
   --registry                    [string]  Docker registry to pull containers from. 
                                             [default: dockerhub]
   --singularity_cache           [string]  Directory where remote Singularity images are stored.


### PR DESCRIPTION
Hey, @rpetit3. I was worried about the conda build time and found that you already implemented a `--use_mamba` parameter that uses mamba within nextflow (very very nice, I loved it!), but I found it on source code but not in the docs.

May I be helpful and add it here and maybe on the bactopia --help? is there any other undocumented parameter? I can help on this minor work.


Feel free to modify or comment on this PR, I'm available to make any necessary modifications.

Kindly, Davi